### PR TITLE
Add support for Gnome

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AutoDark"
 uuid = "496aa92c-90e4-417e-a504-b778f8eb8d5d"
 authors = ["Stefanos Carlström <stefanos.carlstrom@gmail.com> and contributors"]
-version = "1.0.0-DEV"
+version = "1.1.0"
 
 [compat]
 julia = "1.9"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,19 @@
 [![Build Status](https://github.com/jagot/AutoDark.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/jagot/AutoDark.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![Coverage](https://codecov.io/gh/jagot/AutoDark.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/jagot/AutoDark.jl)
 
-React to theme switches. Only supports macOS for now, using
-[dark-notify](https://github.com/cormacrelf/dark-notify).
+React to theme switches.
+Supported operating systems/desktop environments:
+- macOS (using [`dark-notify`](https://github.com/cormacrelf/dark-notify))
+- Gnome (using `gsettings`)
 
 ![AutoDark.jl demo](./demo.gif)
+
+## Usage
+```julia
+using AutoDark
+auto_dark(f)
+```
+This returns immediately and spawns an async thread that listens for changes
+to the color scheme.
+Whenever such a change is detected, it calls `f` with either `:light`, `:dark`
+or `:unknown`.


### PR DESCRIPTION
Nice little package! I stumbled upon it when I wanted to make Makie plots react to the system theme. Even though that doesn't work, I wanted to contribute support for Gnome using gsettings.
Can you check if it still works on macOS, @jagot? I refactored the code a bit but that _should_ not have changed the behaviour on macOS.